### PR TITLE
refactor: 카카오페이 결제 리팩토링 (#7)

### DIFF
--- a/src/main/java/com/spoonsors/spoonsorsserver/common/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/common/config/RedisRepositoryConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /************
@@ -30,11 +31,11 @@ public class RedisRepositoryConfig {
 
     // Redis template
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());   //connection
-        redisTemplate.setKeySerializer(new StringRedisSerializer());    // key
-        redisTemplate.setValueSerializer(new StringRedisSerializer());  // value
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer()); // Key Serializer
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // Value Serializer
         return redisTemplate;
     }
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/common/config/SwaggerConfig.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/common/config/SwaggerConfig.java
@@ -49,7 +49,7 @@ public class SwaggerConfig {
     }
     @Bean
     public GroupedOpenApi sponsorGroup() {
-        String[] paths = {"/sMembers/**"};
+        String[] paths = {"/sMembers/**","/payments/**"};
 
         return GroupedOpenApi.builder()
                 .group("후원자 API")

--- a/src/main/java/com/spoonsors/spoonsorsserver/controller/payment/KakaoPayController.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/controller/payment/KakaoPayController.java
@@ -36,7 +36,7 @@ public class KakaoPayController {
             @ApiResponse(responseCode = "400", description = "후원 가능한 상태가 아님 또는 결제 요청 실패")
     })
     @PostMapping()
-    public ResponseEntity<String> payReady(@RequestBody PaymentDto paymentDto) {
+    public ResponseEntity<RequestPayDto> payReady(@RequestBody PaymentDto paymentDto) {
 
         // 후원 결제 정보 생성
         SponInfoDto sponInfoDto = sponService.getSponInfo(paymentDto.getSpons());
@@ -48,7 +48,7 @@ public class KakaoPayController {
             SponTidDto sponTidDto = SponTidDto.builder().tid(requestPayDto.getTid()).spons(paymentDto.getSpons()).memberId(paymentDto.getMemberId()).build();
             String key = PREFIX + requestPayDto.getSMemberId();
             redisTemplate.opsForValue().set(key,sponTidDto, 5, TimeUnit.MINUTES);
-            return ResponseEntity.ok(requestPayDto.getNext_redirect_app_url());
+            return ResponseEntity.ok(requestPayDto);
         }
 
         throw new ApiException(ExceptionEnum.PAY01); // 결제 요청 실패에 대한 예외 처리

--- a/src/main/java/com/spoonsors/spoonsorsserver/customException/ExceptionEnum.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/customException/ExceptionEnum.java
@@ -35,6 +35,7 @@ public enum ExceptionEnum {
     POST04(HttpStatus.FORBIDDEN, "POST-04", "후원 완료된 글은 삭제 불가능 합니다."),
     POST05(HttpStatus.FORBIDDEN, "POST-05", "후원된 상품이 있는 글은 삭제 불가능 합니다."),
     POST06(HttpStatus.FORBIDDEN, "POST-06", "리뷰가 있는 글은 상태 변경 불가능 합니다."),
+    POST07(HttpStatus.BAD_REQUEST, "POST-07", "올바르지 않은 글입니다."),
 
     JOIN01(HttpStatus.BAD_REQUEST, "JOIN-01", "이미 존재하는 아이디입니다."),
     JOIN02(HttpStatus.BAD_REQUEST, "JOIN-02", "이미 존재하는 닉네임입니다."),
@@ -48,10 +49,13 @@ public enum ExceptionEnum {
 
     PAY01(HttpStatus.BAD_GATEWAY, "PAY-01", "결제 요청 실패"),
     PAY02(HttpStatus.BAD_GATEWAY, "PAY-02", "결제 실패"),
+    PAY03(HttpStatus.BAD_GATEWAY, "PAY-03", "결제 정보를 찾을 수 없음"),
 
     PUSH01(HttpStatus.BAD_REQUEST, "PUSH-01", "state가 올바르지 않습니다."),
 
-    MEALPLANNERNOTFOUND(HttpStatus.NOT_FOUND, "MEALPLANNER-01", "식단을 찾을 수 없습니다.");
+    MEALPLANNERNOTFOUND(HttpStatus.NOT_FOUND, "MEALPLANNER-01", "식단을 찾을 수 없습니다."),
+
+    MEMBER01(HttpStatus.BAD_REQUEST, "MEMBER-01", "사용자를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/spoonsors/spoonsorsserver/customException/ExceptionEnum.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/customException/ExceptionEnum.java
@@ -27,6 +27,7 @@ public enum ExceptionEnum {
     AUTHORIZE02(HttpStatus.BAD_REQUEST, "AUTHORIZE-02","세션이 만료되었습니다."),
 
     SPON01(HttpStatus.FORBIDDEN, "SPON-01","이미 후원이 완료된 물품입니다."),
+    SPON02(HttpStatus.BAD_REQUEST, "SPON-02","존재하지 않는후원입니다."),
 
     POST01(HttpStatus.FORBIDDEN, "POST-01", "인증이 되지 않은 사용자입니다."),
     POST02(HttpStatus.FORBIDDEN, "POST-02", "후원 등록 가능 상태가 아닙니다."),

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/BMember.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/BMember.java
@@ -2,6 +2,7 @@ package com.spoonsors.spoonsorsserver.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
@@ -21,6 +22,7 @@ import java.util.List;
                 )
         }
 )
+@NoArgsConstructor(force = true)
 public class BMember extends Member {
     @Column(name = "b_member_birth", nullable = false)
     private LocalDate bMemberBirth;

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/Ingredients.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/Ingredients.java
@@ -11,6 +11,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder
 @Entity
+@NoArgsConstructor(force = true)
 public class Ingredients extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/Post.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/Post.java
@@ -3,6 +3,7 @@ package com.spoonsors.spoonsorsserver.entity;
 import com.spoonsors.spoonsorsserver.entity.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -15,6 +16,7 @@ import java.util.List;
 @Getter
 @SuperBuilder
 @Entity
+@NoArgsConstructor(force = true)
 public class Post extends BaseEntity {
 
     @Id

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/Spon.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/Spon.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 @Getter
 @SuperBuilder
 @Entity
+@NoArgsConstructor(force = true)
 public class Spon extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO) //MySQL의 AUTO_INCREMENT를 사용

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/payment/PaymentDto.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/payment/PaymentDto.java
@@ -10,6 +10,6 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class PaymentDto {
-    String member_id;
-    List<Long> spon_list;
+    String memberId;
+    List<Long> spons;
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/payment/RequestPayDto.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/payment/RequestPayDto.java
@@ -12,6 +12,10 @@ import java.util.Date;
 public class RequestPayDto {
     private String tid;
     private String next_redirect_app_url;
+    private String next_redirect_mobile_url;
+    private String next_redirect_pc_url;
+    private String android_app_scheme;
+    private String ios_app_scheme;
     private Date created_at;
     private String SMemberId;
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponInfoDto.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponInfoDto.java
@@ -1,0 +1,12 @@
+package com.spoonsors.spoonsorsserver.entity.spon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SponInfoDto {
+    public String itemName;
+    public int totalPrice;
+    public int quantity;
+}

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponTidDto.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponTidDto.java
@@ -1,0 +1,14 @@
+package com.spoonsors.spoonsorsserver.entity.spon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SponTidDto {
+    String memberId;
+    List<Long> spons;
+    public String tid;
+}

--- a/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponTidDto.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/entity/spon/SponTidDto.java
@@ -1,12 +1,16 @@
 package com.spoonsors.spoonsorsserver.entity.spon;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SponTidDto {
     String memberId;
     List<Long> spons;

--- a/src/main/java/com/spoonsors/spoonsorsserver/repository/ISponRepository.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/repository/ISponRepository.java
@@ -7,10 +7,12 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+
 @Repository
 public interface ISponRepository extends JpaRepository<Spon, Long> {
 
     @Modifying
-    @Query("UPDATE Spon s SET s.tid = :tid WHERE s.sponId = :sponId")
-    void updateTid(@Param("tid") String tid, @Param("sponId") Long sponId);
+    @Query("UPDATE Spon s SET s.tid = :tid, s.sponDate = :sponDate, s.sMember.id = :sMemberId, s.isSponed = true WHERE s.sponId = :sponId")
+    void updateSpon(@Param("tid") String tid, @Param("sponId") Long sponId, @Param("sponDate") LocalDate sponDate, @Param("sMemberId") String sMemberId);
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/repository/ISponRepository.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/repository/ISponRepository.java
@@ -1,7 +1,16 @@
 package com.spoonsors.spoonsorsserver.repository;
 
 import com.spoonsors.spoonsorsserver.entity.Spon;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ISponRepository extends JpaRepository<Spon, Long> {
+
+    @Modifying
+    @Query("UPDATE Spon s SET s.tid = :tid WHERE s.sponId = :sponId")
+    void updateTid(@Param("tid") String tid, @Param("sponId") Long sponId);
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/repository/PostRepository.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/repository/PostRepository.java
@@ -14,9 +14,9 @@ public class PostRepository {
 
     private final EntityManager em;
 
-    public void changeRemain(Long post_id){
+    public void changeRemain(Long post_id, int sponAmount){
         Post post = em.find(Post.class, post_id);
-        post.setRemainSpon(post.getRemainSpon()-1);
+        post.setRemainSpon(post.getRemainSpon()-sponAmount);
     }
 
     public String changeState(Long post_id){

--- a/src/main/java/com/spoonsors/spoonsorsserver/service/member/PostService.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/service/member/PostService.java
@@ -127,4 +127,12 @@ public class PostService {
         Post post = optionalPost.get();
         return post.isHasReview();
     }
+
+    public void changeRemain(Long postId, int sponAmount){
+        Post post = iPostRepository.findById(postId).orElseThrow(() -> new ApiException(ExceptionEnum.POST07));
+        postRepository.changeRemain(postId, sponAmount);
+        if(post.getRemainSpon()==0){ //더이상 남은 후원이 없으면 글 완료 처리
+            postRepository.changeState(post.getPostId());
+        }
+    }
 }

--- a/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
@@ -1,12 +1,8 @@
 package com.spoonsors.spoonsorsserver.service.payment;
 
-import com.spoonsors.spoonsorsserver.entity.Ingredients;
-import com.spoonsors.spoonsorsserver.entity.Spon;
 import com.spoonsors.spoonsorsserver.entity.payment.ApproveRequestPayDto;
-import com.spoonsors.spoonsorsserver.entity.payment.PaymentDto;
 import com.spoonsors.spoonsorsserver.entity.payment.RequestPayDto;
-import com.spoonsors.spoonsorsserver.repository.ISponRepository;
-import com.spoonsors.spoonsorsserver.repository.SponRepository;
+import com.spoonsors.spoonsorsserver.entity.spon.SponInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -18,9 +14,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
-import java.util.Optional;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -29,33 +22,19 @@ public class KakaoPayService {
 
     private ApproveRequestPayDto approveRequestPayDto;
     private RequestPayDto requestPayDto;
-    private final ISponRepository iSponRepository;
-    private final SponRepository sponRepository;
 
-    public String payReady(PaymentDto paymentDto) {
-        List<Long> sponList = paymentDto.getSpon_list();
-        String item_name="";
-        int total_price=0;
-        for (Long spon_id : sponList) {
-            Optional<Spon> optionalSpon= iSponRepository.findById(spon_id);
-            Spon spon = optionalSpon.get();
-            Ingredients ingredients = spon.getIngredients();
-            item_name=ingredients.getIngredientsName();
-            total_price += ingredients.getPrice();
-        }
-        int quantity=sponList.size()-1;
-        if(sponList.size()!=1){ //여러건일 경우, 결제 상품 명 변경
-            item_name=item_name+"외 "+quantity+"건";
-        }
+    @Transactional
+    public RequestPayDto payReady(String memberId, SponInfoDto sponInfoDto) {
 
-        // 카카오가 요구한 결제요청request값을 담아줍니다.
+        // 카카오가 요구한 결제요청 request값을 담아줍니다.
+
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.add("cid", "TC0ONETIME"); //가맹점 코드. 10자 실제 제휴 후 받아야함
         parameters.add("partner_order_id", "partner_order_id"); // 가맹점의 주문번호
-        parameters.add("partner_user_id", paymentDto.getMember_id());
-        parameters.add("item_name", item_name);
-        parameters.add("quantity", "1");
-        parameters.add("total_amount", String.valueOf(total_price));
+        parameters.add("partner_user_id", memberId);
+        parameters.add("item_name", sponInfoDto.getItemName());
+        parameters.add("quantity", String.valueOf(sponInfoDto.getQuantity()));
+        parameters.add("total_amount", String.valueOf(sponInfoDto.getTotalPrice()));
         parameters.add("tax_free_amount", "0");
         parameters.add("approval_url", "http://15.165.106.139:8080/sMember/kakaoPay/completed"); // 결제승인시 넘어갈 url
         parameters.add("cancel_url", "http://15.165.106.139:8080/sMember/kakaoPay/cancel"); // 결제취소시 넘어갈 url
@@ -63,27 +42,22 @@ public class KakaoPayService {
 
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
         // 외부url요청 통로 열기.
-        try{
+        try {
             RestTemplate template = new RestTemplate();
             String url = "https://kapi.kakao.com/v1/payment/ready";
 
-            requestPayDto  = template.postForObject(url, requestEntity, RequestPayDto.class);
+            RequestPayDto requestPayDto = template.postForObject(url, requestEntity, RequestPayDto.class);
 
-            if(requestPayDto !=null){
-                requestPayDto.setSMemberId(paymentDto.getMember_id());
-                for (Long spon_id : sponList) {
-                    sponRepository.putTid(spon_id, requestPayDto.getTid());
-                }
-                return requestPayDto.getNext_redirect_app_url();
+            if (requestPayDto != null) {
+                requestPayDto.setSMemberId(memberId);
             }
 
-            return null;
+            return requestPayDto;
 
         } catch (RestClientException e) {
             e.printStackTrace();
+            return null;
         }
-
-        return "결제 요청 실패";
     }
 
     // 결제 승인요청 메서드

--- a/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
@@ -21,7 +21,6 @@ import org.springframework.web.client.RestTemplate;
 public class KakaoPayService {
 
     private ApproveRequestPayDto approveRequestPayDto;
-    private RequestPayDto requestPayDto;
 
     @Transactional
     public RequestPayDto payReady(String memberId, SponInfoDto sponInfoDto) {
@@ -36,9 +35,9 @@ public class KakaoPayService {
         parameters.add("quantity", String.valueOf(sponInfoDto.getQuantity()));
         parameters.add("total_amount", String.valueOf(sponInfoDto.getTotalPrice()));
         parameters.add("tax_free_amount", "0");
-        parameters.add("approval_url", "http://15.165.106.139:8080/sMember/kakaoPay/completed"); // 결제승인시 넘어갈 url
-        parameters.add("cancel_url", "http://15.165.106.139:8080/sMember/kakaoPay/cancel"); // 결제취소시 넘어갈 url
-        parameters.add("fail_url", "http://15.165.106.139:8080/sMember/kakaoPay/fail"); // 결제 실패시 넘어갈 url
+        parameters.add("approval_url", "https://localhost:8080/payments/kakao/complete"); // 결제승인시 넘어갈 url
+        parameters.add("cancel_url", "https://localhost:8080/payments/kakao/cancel"); // 결제취소시 넘어갈 url
+        parameters.add("fail_url", "https://localhost:8080/payments/kakao/fail"); // 결제 실패시 넘어갈 url
 
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
         // 외부url요청 통로 열기.
@@ -61,14 +60,15 @@ public class KakaoPayService {
     }
 
     // 결제 승인요청 메서드
-    public ApproveRequestPayDto payApprove( String pgToken) {
+    @Transactional
+    public ApproveRequestPayDto payApprove( String pgToken, String tid, String sMemberId) {
         log.info("----------------------------payApprove" );
 
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.add("cid", "TC0ONETIME"); //가맹점 코드. 10자 실제 제휴 후 받아야함
-        parameters.add("tid", requestPayDto.getTid()); //결제 고유번호
+        parameters.add("tid", tid); //결제 고유번호
         parameters.add("partner_order_id", "partner_order_id"); // 가맹점 주문번호, 결제 준비 api요청과 일치 필요
-        parameters.add("partner_user_id", requestPayDto.getSMemberId() ); //가맹점 회원 id, 결제 준비 api 요청과 일치
+        parameters.add("partner_user_id", sMemberId ); //가맹점 회원 id, 결제 준비 api 요청과 일치
         parameters.add("pg_token", pgToken);
 
         // 하나의 map안에 header와 parameter값을 담아줌.

--- a/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
+++ b/src/main/java/com/spoonsors/spoonsorsserver/service/payment/KakaoPayService.java
@@ -4,22 +4,28 @@ import com.spoonsors.spoonsorsserver.entity.payment.ApproveRequestPayDto;
 import com.spoonsors.spoonsorsserver.entity.payment.RequestPayDto;
 import com.spoonsors.spoonsorsserver.entity.spon.SponInfoDto;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-@Slf4j
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
-@Transactional
+@PropertySource("classpath:application.properties")
 public class KakaoPayService {
 
+    @Value("${kakao.cid}")
+    private String CID;
+
+    @Value("${kakao.secretKey}")
+    private String SECRET_KEY;
     private ApproveRequestPayDto approveRequestPayDto;
 
     @Transactional
@@ -27,23 +33,25 @@ public class KakaoPayService {
 
         // 카카오가 요구한 결제요청 request값을 담아줍니다.
 
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("cid", "TC0ONETIME"); //가맹점 코드. 10자 실제 제휴 후 받아야함
-        parameters.add("partner_order_id", "partner_order_id"); // 가맹점의 주문번호
-        parameters.add("partner_user_id", memberId);
-        parameters.add("item_name", sponInfoDto.getItemName());
-        parameters.add("quantity", String.valueOf(sponInfoDto.getQuantity()));
-        parameters.add("total_amount", String.valueOf(sponInfoDto.getTotalPrice()));
-        parameters.add("tax_free_amount", "0");
-        parameters.add("approval_url", "https://localhost:8080/payments/kakao/complete"); // 결제승인시 넘어갈 url
-        parameters.add("cancel_url", "https://localhost:8080/payments/kakao/cancel"); // 결제취소시 넘어갈 url
-        parameters.add("fail_url", "https://localhost:8080/payments/kakao/fail"); // 결제 실패시 넘어갈 url
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("cid", CID); //가맹점 코드. 10자 실제 제휴 후 받아야함
+        parameters.put("partner_order_id", "partner_order_id"); // 가맹점의 주문번호
+        parameters.put("partner_user_id", memberId);
+        parameters.put("item_name", sponInfoDto.getItemName());
+        parameters.put("quantity", String.valueOf(sponInfoDto.getQuantity()));
+        parameters.put("total_amount", String.valueOf(sponInfoDto.getTotalPrice()));
+        parameters.put("tax_free_amount", "0");
+        parameters.put("approval_url", "http://localhost:8080/payments/kakao/complete"); // 결제승인시 넘어갈 url
+        parameters.put("cancel_url", "http://localhost:8080/payments/kakao/cancel"); // 결제취소시 넘어갈 url
+        parameters.put("fail_url", "http://localhost:8080/payments/kakao/fail"); // 결제 실패시 넘어갈 url
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
+
+
         // 외부url요청 통로 열기.
         try {
             RestTemplate template = new RestTemplate();
-            String url = "https://kapi.kakao.com/v1/payment/ready";
+            String url = "https://open-api.kakaopay.com/online/v1/payment/ready";
 
             RequestPayDto requestPayDto = template.postForObject(url, requestEntity, RequestPayDto.class);
 
@@ -62,25 +70,23 @@ public class KakaoPayService {
     // 결제 승인요청 메서드
     @Transactional
     public ApproveRequestPayDto payApprove( String pgToken, String tid, String sMemberId) {
-        log.info("----------------------------payApprove" );
 
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("cid", "TC0ONETIME"); //가맹점 코드. 10자 실제 제휴 후 받아야함
-        parameters.add("tid", tid); //결제 고유번호
-        parameters.add("partner_order_id", "partner_order_id"); // 가맹점 주문번호, 결제 준비 api요청과 일치 필요
-        parameters.add("partner_user_id", sMemberId ); //가맹점 회원 id, 결제 준비 api 요청과 일치
-        parameters.add("pg_token", pgToken);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("cid", CID); //가맹점 코드. 10자 실제 제휴 후 받아야함
+        parameters.put("tid", tid); //결제 고유번호
+        parameters.put("partner_order_id", "partner_order_id"); // 가맹점 주문번호, 결제 준비 api요청과 일치 필요
+        parameters.put("partner_user_id", sMemberId ); //가맹점 회원 id, 결제 준비 api 요청과 일치
+        parameters.put("pg_token", pgToken);
 
         // 하나의 map안에 header와 parameter값을 담아줌.
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
 
         // 외부url 통신
         try {
             RestTemplate template = new RestTemplate();
-            String url = "https://kapi.kakao.com/v1/payment/approve";
+            String url = "https://open-api.kakaopay.com/online/v1/payment/approve";
             // 보낼 외부 url, 요청 메시지(header,parameter), 처리후 값을 받아올 클래스.
             approveRequestPayDto = template.postForObject(url, requestEntity, ApproveRequestPayDto.class);
-            log.info("----------------------------approveRequestPayDto={}", approveRequestPayDto.getTid() );
             return approveRequestPayDto;
         }catch (RestClientException e) {
 
@@ -92,8 +98,8 @@ public class KakaoPayService {
 
     private HttpHeaders getHeaders() {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization","KakaoAK 942dc22415c337900d9f5159a808d612" );
-        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.set("Authorization","SECRET_KEY "+SECRET_KEY );
+        headers.set("Content-type", "application/json");
 
         return headers;
     }


### PR DESCRIPTION
- 후원자 swagger에 결제 뜨도록 변경
- 관련 DTO 카멜케이스로 변경
- 결제 요청 -> 승인 레디스 적용
- 레디스 적용에 따른 후원 등록 로직 수정 (기존 tid 기준 조회 후 정보 업데이트 방식에서 tid와 새 정보 한 번에 업데이트로 변경)
- kakao Developers 지원 중단 및 kakaoPayDevelopers 이전에 따른 코드 수정
- 리턴 형식 수정(app/web url 모두 리턴)
